### PR TITLE
Changed parameter name in Path.rs file

### DIFF
--- a/swagger/src/path.rs
+++ b/swagger/src/path.rs
@@ -81,7 +81,7 @@ pub struct PathItem {
     #[serde(rename = "$ref")]
     pub item_ref: Option<String>,
     pub summary: Option<String>,
-    pub descrition: Option<String>,
+    pub description: Option<String>,
     pub get: Option<Operation>,
     pub put: Option<Operation>,
     pub post: Option<Operation>,


### PR DESCRIPTION
Made changes in the path.rs file. Changed **descrition** to **description** in pub struct PathItem. Can someone please verify